### PR TITLE
Update `nvmlDeviceGetMemoryInfo` to version 2 to be consistent with `nvidia-smi`

### DIFF
--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -5431,7 +5431,7 @@ mod test {
     #[test]
     fn memory_info() {
         let nvml = nvml();
-        test_with_device(3, &nvml, |device| device.memory_info());
+        test_with_device(3, &nvml, |device| device.memory_info())
     }
 
     #[cfg(target_os = "linux")]

--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -1963,13 +1963,12 @@ impl<'nvml> Device<'nvml> {
 
         unsafe {
             let mut info: nvmlMemory_v2_t = mem::zeroed();
+
             // Implements NVML_STRUCT_VERSION(Memory, 2), as detailed in nvml.h (https://github.com/NVIDIA/nvidia-settings/issues/78)
             info.version = (std::mem::size_of::<nvmlMemory_v2_t>() | (2_usize << 24_usize)) as u32;
             nvml_try(sym(self.device, &mut info))?;
 
-            let result = info.into();
-
-            Ok(result)
+            Ok(info.into())
         }
     }
 
@@ -5320,7 +5319,6 @@ mod test {
     }
 
     #[test]
-    #[ignore = "my machine doesn't support this call"]
     fn fan_speed() {
         let nvml = nvml();
         test_with_device(3, &nvml, |device| device.fan_speed(0))

--- a/nvml-wrapper/src/struct_wrappers/device.rs
+++ b/nvml-wrapper/src/struct_wrappers/device.rs
@@ -291,6 +291,7 @@ pub struct MemoryInfo {
     /// Unallocated FB memory.
     pub free: u64,
 
+    /// Reserved FB memory.
     pub reserved: u64,
 
     /// Total installed FB memory.
@@ -301,6 +302,7 @@ pub struct MemoryInfo {
     /// bookkeeping.
     pub used: u64,
 
+    /// Struct version, must be set according to API specification before calling the API.
     pub version: u32
 }
 

--- a/nvml-wrapper/src/struct_wrappers/device.rs
+++ b/nvml-wrapper/src/struct_wrappers/device.rs
@@ -290,6 +290,9 @@ impl From<nvmlEccErrorCounts_t> for EccErrorCounts {
 pub struct MemoryInfo {
     /// Unallocated FB memory.
     pub free: u64,
+
+    pub reserved: u64,
+
     /// Total installed FB memory.
     pub total: u64,
     /// Allocated FB memory.
@@ -297,14 +300,18 @@ pub struct MemoryInfo {
     /// Note that the driver/GPU always sets aside a small amount of memory for
     /// bookkeeping.
     pub used: u64,
+
+    pub version: u32
 }
 
-impl From<nvmlMemory_t> for MemoryInfo {
-    fn from(struct_: nvmlMemory_t) -> Self {
+impl From<nvmlMemory_v2_t> for MemoryInfo {
+    fn from(struct_: nvmlMemory_v2_t) -> Self {
         Self {
             free: struct_.free,
+            reserved: struct_.reserved,
             total: struct_.total,
             used: struct_.used,
+            version: struct_.version
         }
     }
 }

--- a/nvml-wrapper/src/struct_wrappers/device.rs
+++ b/nvml-wrapper/src/struct_wrappers/device.rs
@@ -303,7 +303,7 @@ pub struct MemoryInfo {
     pub used: u64,
 
     /// Struct version, must be set according to API specification before calling the API.
-    pub version: u32
+    pub version: u32,
 }
 
 impl From<nvmlMemory_v2_t> for MemoryInfo {
@@ -313,7 +313,7 @@ impl From<nvmlMemory_v2_t> for MemoryInfo {
             reserved: struct_.reserved,
             total: struct_.total,
             used: struct_.used,
-            version: struct_.version
+            version: struct_.version,
         }
     }
 }


### PR DESCRIPTION
Update API call used in `Device::memory_info` to use `nvmlDeviceGetMemoryInfo_v2`.

Fixes #57.