### PR TITLE
Set LIB_PATH to libnvidia-ml.so.1 instead of libnvidia-ml.so on Linux

### DIFF
--- a/nvml-wrapper/src/lib.rs
+++ b/nvml-wrapper/src/lib.rs
@@ -155,7 +155,7 @@ use crate::bitmasks::InitFlags;
 const LIB_PATH: &str = "nvml.dll";
 
 #[cfg(target_os = "linux")]
-const LIB_PATH: &str = "libnvidia-ml.so";
+const LIB_PATH: &str = "libnvidia-ml.so.1";
 
 /// Determines the major version of the CUDA driver given the full version.
 ///


### PR DESCRIPTION
In the official Go bindings for NVML, they use libnvidia-ml.so.1: https://github.com/NVIDIA/go-nvml/blob/0e815c71ca6e8184387d8b502b2ef2d2722165b9/pkg/nvml/lib.go#L30, and I believe the same is true for pynvml.