### PR TITLE
Include license text in the packaged crates

### DIFF
--- a/nvml-wrapper-sys/LICENSE-APACHE
+++ b/nvml-wrapper-sys/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/nvml-wrapper-sys/LICENSE-MIT
+++ b/nvml-wrapper-sys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/nvml-wrapper/LICENSE-APACHE
+++ b/nvml-wrapper/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/nvml-wrapper/LICENSE-MIT
+++ b/nvml-wrapper/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
The crates in this project don't currently include the license text, which is technically a requirement for MIT. This PR ensures they will be included in future builds.