### PR TITLE
feat: add attestation report fetch functionality to device

### DIFF
--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -762,7 +762,6 @@ impl<'nvml> Device<'nvml> {
     * `InvalidArg`, if device is invalid or memory is NULL
     * `NotSupported`, if this query is not supported by the device
     * `Unknown`, on any unexpected error
-    
     */
     #[doc(alias = "nvmlDeviceGetAttestationReport")]
     pub fn fetch_attestation_report(&self) -> Result<Vec<u8>, NvmlError> {
@@ -778,13 +777,13 @@ impl<'nvml> Device<'nvml> {
 
             nvml_try(sym(self.device, report))?;
             let mut attestation_report = Vec::new();
-            attestation_report.extend_from_slice(&(*report).nonce.to_vec());
+            attestation_report.extend_from_slice(&(*report).nonce);
             attestation_report.extend_from_slice(&(*report).attestationReportSize.to_be_bytes());
-            attestation_report.extend_from_slice(&(*report).attestationReport.to_vec());
+            attestation_report.extend_from_slice(&(*report).attestationReport);
             attestation_report.extend_from_slice(&(*report).isCecAttestationReportPresent.to_be_bytes());
             attestation_report.extend_from_slice(&(*report).cecAttestationReportSize.to_be_bytes());
-            attestation_report.extend_from_slice(&(*report).cecAttestationReport.to_vec());
-           
+            attestation_report.extend_from_slice(&(*report).cecAttestationReport);
+            
             Ok(attestation_report)
         }
     }

--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -759,10 +759,10 @@ impl<'nvml> Device<'nvml> {
     # Errors
 
     * `Uninitialized`, if the library has not been successfully initialized
-    * `InvalidArg`, if `device` is invalid
-    * `NotSupported`, if this operation is not supported by the device
-    * `GPUIsLost`, if the target GPU has fallen off the bus or is otherwise inaccessible
+    * `InvalidArg`, if device is invalid or memory is NULL
+    * `NotSupported`, if this query is not supported by the device
     * `Unknown`, on any unexpected error
+    
     */
     #[doc(alias = "nvmlDeviceGetAttestationReport")]
     pub fn fetch_attestation_report(&self) -> Result<Vec<u8>, NvmlError> {

--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -784,10 +784,10 @@ impl<'nvml> Device<'nvml> {
             let is_cec_attestation_report_present = report.isCecAttestationReportPresent == 1;
             Ok(ConfidentialComputeGpuAttestationReport {
                 attestation_report_size: report.attestationReportSize,
-                attestation_report: report.attestationReport,
+                attestation_report: report.attestationReport.to_vec(),
                 is_cec_attestation_report_present,
                 cec_attestation_report_size: report.cecAttestationReportSize,
-                cec_attestation_report: report.cecAttestationReport,
+                cec_attestation_report: report.cecAttestationReport.to_vec(),
             })
         }
     }

--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -783,7 +783,6 @@ impl<'nvml> Device<'nvml> {
 
             let is_cec_attestation_report_present = report.isCecAttestationReportPresent == 1;
             Ok(ConfidentialComputeGpuAttestationReport {
-                nonce: report.nonce,
                 attestation_report_size: report.attestationReportSize,
                 attestation_report: report.attestationReport,
                 is_cec_attestation_report_present,

--- a/nvml-wrapper/src/structs/device.rs
+++ b/nvml-wrapper/src/structs/device.rs
@@ -1,7 +1,6 @@
 #[cfg(target_os = "windows")]
 use crate::enum_wrappers::device::DriverModel;
 use crate::enum_wrappers::device::OperationMode;
-use ffi::bindings::{NVML_CC_GPU_ATTESTATION_REPORT_SIZE, NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE};
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 
@@ -11,14 +10,16 @@ use serde_derive::{Deserialize, Serialize};
 pub struct ConfidentialComputeGpuAttestationReport {
     /// The size of the attestation report.
     pub attestation_report_size: u32,
-    /// The attestation report.
-    pub attestation_report: [u8; NVML_CC_GPU_ATTESTATION_REPORT_SIZE as usize],
+    /// The attestation report, of size
+    /// `ffi::bindings::NVML_CC_GPU_ATTESTATION_REPORT_SIZE` == 8192 bytes.
+    pub attestation_report: Vec<u8>,
     /// Whether the CEC attestation report is present.
     pub is_cec_attestation_report_present: bool,
     /// The size of the CEC attestation report.
     pub cec_attestation_report_size: u32,
-    /// The CEC attestation report.
-    pub cec_attestation_report: [u8; NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE as usize],
+    /// The CEC attestation report, of size
+    /// `ffi::bindings::NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE` == 4096 bytes.
+    pub cec_attestation_report: Vec<u8>,
 }
 
 /// Returned from `Device.auto_boosted_clocks_enabled()`

--- a/nvml-wrapper/src/structs/device.rs
+++ b/nvml-wrapper/src/structs/device.rs
@@ -12,9 +12,6 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ConfidentialComputeGpuAttestationReport {
-    /// The nonce used to generate the attestation report. It is used to ensure the integrity of the report,
-    /// by avoiding replay attacks.
-    pub nonce: [u8; NVML_CC_GPU_CEC_NONCE_SIZE as usize],
     /// The size of the attestation report.
     pub attestation_report_size: u32,
     /// The attestation report.

--- a/nvml-wrapper/src/structs/device.rs
+++ b/nvml-wrapper/src/structs/device.rs
@@ -1,10 +1,7 @@
 #[cfg(target_os = "windows")]
 use crate::enum_wrappers::device::DriverModel;
 use crate::enum_wrappers::device::OperationMode;
-use ffi::bindings::{
-    NVML_CC_GPU_ATTESTATION_REPORT_SIZE, NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE,
-    NVML_CC_GPU_CEC_NONCE_SIZE,
-};
+use ffi::bindings::{NVML_CC_GPU_ATTESTATION_REPORT_SIZE, NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE};
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 

--- a/nvml-wrapper/src/structs/device.rs
+++ b/nvml-wrapper/src/structs/device.rs
@@ -1,8 +1,31 @@
 #[cfg(target_os = "windows")]
 use crate::enum_wrappers::device::DriverModel;
 use crate::enum_wrappers::device::OperationMode;
+use ffi::bindings::{
+    NVML_CC_GPU_ATTESTATION_REPORT_SIZE, NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE,
+    NVML_CC_GPU_CEC_NONCE_SIZE,
+};
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
+
+/// Returned from `Device.confidential_compute_gpu_attestation_report_bytes()`
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ConfidentialComputeGpuAttestationReport {
+    /// The nonce used to generate the attestation report. It is used to ensure the integrity of the report,
+    /// by avoiding replay attacks.
+    pub nonce: [u8; NVML_CC_GPU_CEC_NONCE_SIZE as usize],
+    /// The size of the attestation report.
+    pub attestation_report_size: u32,
+    /// The attestation report.
+    pub attestation_report: [u8; NVML_CC_GPU_ATTESTATION_REPORT_SIZE as usize],
+    /// Whether the CEC attestation report is present.
+    pub is_cec_attestation_report_present: bool,
+    /// The size of the CEC attestation report.
+    pub cec_attestation_report_size: u32,
+    /// The CEC attestation report.
+    pub cec_attestation_report: [u8; NVML_CC_GPU_CEC_ATTESTATION_REPORT_SIZE as usize],
+}
 
 /// Returned from `Device.auto_boosted_clocks_enabled()`
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]


### PR DESCRIPTION
# Add Confidential Computing GPU Certificate and Attestation Report Support

This PR adds support for two NVML confidential computing functions:

1. `nvmlDeviceGetConfComputeGpuCertificate` - Retrieves the GPU certificate for confidential computing
2. `nvmlDeviceGetConfComputeGpuAttestationReport` - Fetches the attestation report for confidential computing

## Implementation Details

- Added `ConfidentialComputeGpuCertificate` struct to represent the certificate data
- Added `ConfidentialComputeGpuAttestationReport` struct to represent the attestation report
- Implemented corresponding methods on the `Device` struct to access these features
- Added proper documentation with error conditions and usage information
- Imported necessary constants from the FFI bindings

## Use Cases

These additions enable applications to:
- Verify the authenticity of NVIDIA GPUs in confidential computing environments
- Generate attestation reports that can be used in remote attestation workflows
- Support secure GPU workloads in confidential computing scenarios