### PR TITLE
feat: add confidential compute gpu certificate functionality

### DIFF
--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -792,6 +792,39 @@ impl<'nvml> Device<'nvml> {
     }
 
     /**
+    Gets the confidential compute GPU certificate for this `Device`.
+
+    # Errors
+
+    * `Uninitialized` if the library has not been successfully initialized
+    * `InvalidArg` if device is invalid or memory is NULL
+    * `NotSupported` if this query is not supported by the device
+    * `Unknown` on any unexpected error
+    */
+    pub fn confidential_compute_gpu_certificate(
+        &self,
+    ) -> Result<ConfidentialComputeGpuCertificate, NvmlError> {
+        let sym = nvml_sym(
+            self.nvml
+                .lib
+                .nvmlDeviceGetConfComputeGpuCertificate
+                .as_ref(),
+        )?;
+
+        unsafe {
+            let mut certificate_chain: nvmlConfComputeGpuCertificate_t = mem::zeroed();
+            nvml_try(sym(self.device, &mut certificate_chain))?;
+
+            Ok(ConfidentialComputeGpuCertificate {
+                cert_chain_size: certificate_chain.certChainSize,
+                attestation_cert_chain_size: certificate_chain.attestationCertChainSize,
+                cert_chain: certificate_chain.certChain.to_vec(),
+                attestation_cert_chain: certificate_chain.attestationCertChain.to_vec(),
+            })
+        }
+    }
+
+    /**
     Gets the current PCIe link generation.
 
     # Errors

--- a/nvml-wrapper/src/structs/device.rs
+++ b/nvml-wrapper/src/structs/device.rs
@@ -22,6 +22,22 @@ pub struct ConfidentialComputeGpuAttestationReport {
     pub cec_attestation_report: Vec<u8>,
 }
 
+/// Returned from `Device.confidential_compute_gpu_certificate()`
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ConfidentialComputeGpuCertificate {
+    /// The size of the certificate chain.
+    pub cert_chain_size: u32,
+    /// The size of the attestation certificate chain.
+    pub attestation_cert_chain_size: u32,
+    /// The certificate chain, of size
+    /// `ffi::bindings::NVML_GPU_CERT_CHAIN_SIZE` == 4096 bytes.
+    pub cert_chain: Vec<u8>,
+    /// The attestation certificate chain, of size
+    /// `ffi::bindings::NVML_GPU_ATTESTATION_CERT_CHAIN_SIZE` == 5120 bytes.
+    pub attestation_cert_chain: Vec<u8>,
+}
+
 /// Returned from `Device.auto_boosted_clocks_enabled()`
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
# Add Confidential Compute GPU Certificate Support

This PR adds support for retrieving confidential compute GPU certificates from NVIDIA devices through the NVML API. The implementation includes:

1. A new `ConfidentialComputeGpuCertificate` struct that encapsulates certificate data
2. A method on the `Device` struct to retrieve the certificate information

## Changes

- Added `confidential_compute_gpu_certificate()` method to the `Device` implementation
- Created a new `ConfidentialComputeGpuCertificate` struct to hold certificate data
- Added appropriate documentation for the new functionality

## Use Case

This functionality is useful for applications that need to verify the authenticity of NVIDIA GPUs in confidential computing environments, where hardware attestation is required for security purposes.

## Testing

The implementation has been tested on systems with compatible NVIDIA hardware that support confidential computing features.
