### PR TITLE
Fix get cc macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ each time it gets called. Instead, call `Nvml::init` once and store the resultin
 ## NVML Support
 
 This wrapper is being developed against and currently supports NVML version
-11. Each new version of NVML is guaranteed to be backwards-compatible according
+12. Each new version of NVML is guaranteed to be backwards-compatible according
 to NVIDIA, so this wrapper should continue to work without issue regardless of
 NVML version bumps.
 

--- a/nvml-wrapper/src/device.rs
+++ b/nvml-wrapper/src/device.rs
@@ -882,6 +882,9 @@ impl<'nvml> Device<'nvml> {
 
         unsafe {
             let mut settings: nvmlSystemConfComputeSettings_t = mem::zeroed();
+            // Implements NVML_STRUCT_VERSION(SystemConfComputeSettings, 1), as detailed in nvml.h
+            settings.version = (std::mem::size_of::<nvmlSystemConfComputeSettings_v1_t>()
+                | (1_usize << 24_usize)) as u32;
             nvml_try(sym(&mut settings))?;
             Ok(settings.ccFeature == NVML_CC_SYSTEM_FEATURE_ENABLED)
         }
@@ -904,6 +907,9 @@ impl<'nvml> Device<'nvml> {
 
         unsafe {
             let mut settings: nvmlSystemConfComputeSettings_t = mem::zeroed();
+            // Implements NVML_STRUCT_VERSION(SystemConfComputeSettings, 1), as detailed in nvml.h
+            settings.version = (std::mem::size_of::<nvmlSystemConfComputeSettings_v1_t>()
+                | (1_usize << 24_usize)) as u32;
             nvml_try(sym(&mut settings))?;
             Ok(settings.multiGpuMode == NVML_CC_SYSTEM_MULTIGPU_PROTECTED_PCIE)
         }
@@ -926,6 +932,9 @@ impl<'nvml> Device<'nvml> {
 
         unsafe {
             let mut settings: nvmlSystemConfComputeSettings_t = mem::zeroed();
+            // Implements NVML_STRUCT_VERSION(SystemConfComputeSettings, 1), as detailed in nvml.h
+            settings.version = (std::mem::size_of::<nvmlSystemConfComputeSettings_v1_t>()
+                | (1_usize << 24_usize)) as u32;
             nvml_try(sym(&mut settings))?;
             Ok(settings.devToolsMode == NVML_CC_SYSTEM_DEVTOOLS_MODE_ON)
         }


### PR DESCRIPTION
nvmlSystemConfComputeSettings expects the version field to be set.
nvml.h defines a macro for that purpose which is implemented in this patch following similar macro implementations like 
https://github.com/rust-nvml/nvml-wrapper/blob/main/nvml-wrapper/src/device.rs#L1835-L1837

fixes #97 